### PR TITLE
CTCH-9885: Add publishDesignation property to CtkHierarchy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <licenses>
         <license>
             <name>IMS GLobal</name>
-            <url> http://imsglobal.org/license</url>
+            <url>http://imsglobal.org/license</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -67,8 +67,9 @@
         <caliper.jdk.version>11</caliper.jdk.version>
         <jackson.version>2.11.0</jackson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
-        <arguments />
+        <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/
+        </sonatypeOssDistMgmtSnapshotsUrl>
+        <arguments/>
     </properties>
 
     <distributionManagement>
@@ -226,7 +227,7 @@
                         <configuration>
                             <target>
                                 <copy todir="${project.build.directory}/test-classes/fixtures">
-                                    <fileset dir="${project.build.directory}/caliper-common-fixtures-develop/fixtures" />
+                                    <fileset dir="${project.build.directory}/caliper-common-fixtures-develop/fixtures"/>
                                 </copy>
                             </target>
                         </configuration>
@@ -296,9 +297,36 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.12</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${project.build.directory}/coverage</outputDirectory>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -409,7 +437,7 @@
                                 <configuration>
                                     <transformers>
                                         <transformer
-                                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                         <transformer
                                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         </transformer>

--- a/src/main/java/org/imsglobal/caliper/entities/resource/CtkHierarchy.java
+++ b/src/main/java/org/imsglobal/caliper/entities/resource/CtkHierarchy.java
@@ -24,12 +24,19 @@ public class CtkHierarchy extends DigitalResource implements CaliperCollection<C
     private final String hierarchyType;
 
     /**
+     * Publish Designation
+     */
+    @JsonProperty("publishDesignation")
+    private final String publishDesignation;
+
+    /**
      * @param builder apply builder object properties to the object.
      */
     protected CtkHierarchy(Builder<?> builder) {
         super(builder);
         this.items = ImmutableList.copyOf(builder.items);
         this.hierarchyType = builder.hierarchyType;
+        this.publishDesignation = builder.publishDesignation;
     }
 
     /**
@@ -52,12 +59,22 @@ public class CtkHierarchy extends DigitalResource implements CaliperCollection<C
     }
 
     /**
+     * Return the publish designation.
+     * @return the publishDesignation
+     */
+    @Nullable
+    public String getPublishDesignation() {
+        return publishDesignation;
+    }
+
+    /**
      * Builder class provides a fluid interface for setting object properties.
      * @param <T> builder.
      */
     public static abstract class Builder<T extends Builder<T>> extends DigitalResource.Builder<T> {
         private List<CaliperDigitalResource> items = Lists.newArrayList();
         private String hierarchyType;
+        private String publishDesignation;
 
         /**
          * Constructor
@@ -71,7 +88,7 @@ public class CtkHierarchy extends DigitalResource implements CaliperCollection<C
          * @return builder.
          */
         public T items(List<CaliperDigitalResource> items) {
-            if(items != null) {
+            if (items != null) {
                 this.items.addAll(items);
             }
             return self();
@@ -92,6 +109,15 @@ public class CtkHierarchy extends DigitalResource implements CaliperCollection<C
          */
         public T hierarchyType(String hierarchyType) {
             this.hierarchyType = hierarchyType;
+            return self();
+        }
+
+        /**
+         * @param publishDesignation
+         * @return builder.
+         */
+        public T publishDesignation(String publishDesignation) {
+            this.publishDesignation = publishDesignation;
             return self();
         }
 


### PR DESCRIPTION
This pull request includes changes to the `pom.xml` file and the `CtkHierarchy` class to add new functionality and improve code quality. The most important changes include adding the `jacoco-maven-plugin` for code coverage, and introducing the `publishDesignation` property to the `CtkHierarchy` class.

Enhancements to `CtkHierarchy` class:

* Introduced a new `publishDesignation` property to the `CtkHierarchy` class with corresponding getter method and builder method. 

Improvements to `pom.xml`:

* Added the `jacoco-maven-plugin` to the project for code coverage reporting.